### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # README
 ## ER図
-![table](https://user-images.githubusercontent.com/67823080/99186557-677fbd80-2794-11eb-8cfd-394bfd6751c7.png)
-
+![table](https://user-images.githubusercontent.com/67823080/100536916-3eb4f900-3267-11eb-8517-9292fdadd2f8.png)
 
 ## usersテーブル
 | Column             | Type   | Options                 |
@@ -28,7 +27,7 @@
 | description         | text       | null: false                  |
 | category_id         | integer    | null: false                  |
 | status_id           | integer    | null: false                  |
-| shipping_charges_id | integer    | null: false                  |
+| shipping_charge_id  | integer    | null: false                  |
 | from_area_id        | integer    | null: false                  |
 | deliver_leadtime_id | integer    | null: false                  |
 | price               | integer    | null: false                  |

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,8 +2,8 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :edit, :create, :update, :destroy]
 
   def index
-    # 全ての商品レコードを含んだインスタンス変数を生成し、ビューに表示する
-    @items = Item.all
+    # 全ての商品レコードを含んだインスタンス変数を生成し、出品順に並び替える
+    @items = Item.order("created_at DESC")
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,22 +2,23 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :edit, :create, :update, :destroy]
 
   def index
+    # 全ての商品レコードを含んだインスタンス変数を生成し、ビューに表示する
+    @items = Item.all
   end
 
   def new
-    # モデルオブジェクト生成
+    # itemモデルオブジェクトを生成する
     @item = Item.new
   end
 
   def create
-    # formのデータを受け取る
+    # 入力フォームのデータを受け取り、入力値に問題がなければ保存する
     @item = Item.new(item_params)
-    # バリデーションで問題があれば、保存はされず「投稿画面」に戻る
+    # バリデーションで問題がなければ保存され、トップページに遷移する。問題があれば保存はされず、「商品入力画面」(/new)に戻る。
     if @item.valid?
       @item.save
       redirect_to root_path
     else
-      # 保存されなければ、newに戻る
       render 'new'
     end
   end
@@ -42,6 +43,11 @@ class ItemsController < ApplicationController
 
   def item_params
     # ストロングパラメータ
-    params.require(:item).permit(:image, :title, :description, :category_id, :status_id, :shipping_charges_id, :from_area_id, :deliver_leadtime_id, :price).merge(user_id: current_user.id)
+    params.require(:item).permit(:image, :title, :description, :category_id, :status_id, :shipping_charge_id, :from_area_id, :deliver_leadtime_id, :price).merge(user_id: current_user.id)
   end
+
+  # def was_attached?
+  #   self.image.attached?
+  # end
+
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -49,5 +49,4 @@ class ItemsController < ApplicationController
   # def was_attached?
   #   self.image.attached?
   # end
-
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,7 @@ class ItemsController < ApplicationController
 
   def index
     # 全ての商品レコードを含んだインスタンス変数を生成し、出品順に並び替える
-    @items = Item.order("created_at DESC")
+    @items = Item.order('created_at DESC')
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -16,7 +16,7 @@ class Item < ApplicationRecord
     with_options numericality: { other_than: 1, message: 'を選択してください' } do
       validates :category_id
       validates :status_id
-      validates :shipping_charges_id
+      validates :shipping_charge_id
       validates :from_area_id
       validates :deliver_leadtime_id
     end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,17 +126,17 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+    <% if @items.present? %>
       <% @items.each do |item|%>
         <li class='list'>
           <%= link_to "#" do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" if item.image.attached?%>
-          <%# 商品が売れていればsold outを表示しましょう %>
+          <%# 商品が売れていればsold outを表示 %>
           <%#div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
+          <%# //商品が売れていればsold outを表示 %>
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
@@ -153,10 +153,8 @@
           <% end %>
         </li>
       <% end %>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
+    <% else %>
       <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
@@ -174,7 +172,7 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
+    <% end %>
       <%# /商品がない場合のダミー %>
     </ul>
   </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,25 +127,32 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
+      <% @items.each do |item|%>
+        <li class='list'>
+          <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" if item.image.attached?%>
+          <%# 商品が売れていればsold outを表示しましょう %>
+          <%#div class='sold-out'>
+            <span>Sold Out!!</span>
+          </div>
+          <%# //商品が売れていればsold outを表示しましょう %>
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.title %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.shipping_charge.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
             </div>
           </div>
         </div>
-        <% end %>
-      </li>
+          <% end %>
+        </li>
+      <% end %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合のダミー %>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -71,7 +71,7 @@
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:shipping_charges_id, ShippingCharge.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:shipping_charge_id, ShippingCharge.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>

--- a/db/migrate/20201115140354_create_items.rb
+++ b/db/migrate/20201115140354_create_items.rb
@@ -5,7 +5,7 @@ class CreateItems < ActiveRecord::Migration[6.0]
       t.text    :description,null: false
       t.integer :category_id,null: false
       t.integer :status_id,null: false
-      t.integer :shipping_charges_id,null: false
+      t.integer :shipping_charge_id,null: false
       t.integer :from_area_id,null: false
       t.integer :deliver_leadtime_id,null: false
       t.integer :price,null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -38,7 +38,7 @@ ActiveRecord::Schema.define(version: 2020_11_15_171845) do
     t.text "description", null: false
     t.integer "category_id", null: false
     t.integer "status_id", null: false
-    t.integer "shipping_charges_id", null: false
+    t.integer "shipping_charge_id", null: false
     t.integer "from_area_id", null: false
     t.integer "deliver_leadtime_id", null: false
     t.integer "price", null: false

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     description         { 'アメリカ旅行の際に購入しました。限定品のため日本では販売されていません。値段交渉承ります。' }
     category_id         { 3 }
     status_id           { 2 }
-    shipping_charges_id { 4 }
+    shipping_charge_id  { 4 }
     from_area_id        { 2 }
     deliver_leadtime_id { 5 }
     price               { 3000 }

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -34,10 +34,10 @@ describe Item do
       @item.valid?
       expect(@item.errors[:status_id]).to include('を選択してください')
     end
-    it 'shipping_charges_idが1ならNG' do
-      @item.shipping_charges_id = '1'
+    it 'shipping_charge_idが1ならNG' do
+      @item.shipping_charge_id = '1'
       @item.valid?
-      expect(@item.errors[:shipping_charges_id]).to include('を選択してください')
+      expect(@item.errors[:shipping_charge_id]).to include('を選択してください')
     end
     it 'from_area_idが1ならNG' do
       @item.from_area_id = '1'

--- a/vendor/table.drawio
+++ b/vendor/table.drawio
@@ -1,6 +1,6 @@
-<mxfile host="65bd71144e" modified="2020-11-15T13:42:52.376Z" agent="5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Code/1.51.0 Chrome/83.0.4103.122 Electron/9.3.3 Safari/537.36" etag="ZnkNoQsBbhccw7G0OMBG" version="13.6.5">
+<mxfile host="65bd71144e" modified="2020-11-29T08:19:26.798Z" agent="5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Code/1.51.1 Chrome/83.0.4103.122 Electron/9.3.3 Safari/537.36" etag="SAAbeNtq6HrHvkeo1OUB" version="13.6.5">
     <diagram id="M88q_a9qLkiQrtESlU7Z" name="ページ1">
-        <mxGraphModel dx="900" dy="830" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" background="#ffffff" math="0" shadow="0">
+        <mxGraphModel dx="935" dy="830" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" background="#ffffff" math="0" shadow="0">
             <root>
                 <mxCell id="0"/>
                 <mxCell id="1" parent="0"/>
@@ -74,7 +74,7 @@
                 <mxCell id="164" value="" style="shape=partialRectangle;html=1;whiteSpace=wrap;collapsible=0;dropTarget=0;pointerEvents=0;fillColor=none;top=0;left=0;bottom=0;right=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="151" vertex="1">
                     <mxGeometry y="136" width="400" height="43" as="geometry"/>
                 </mxCell>
-                <mxCell id="165" value="shipping_charges_id" style="shape=partialRectangle;html=1;whiteSpace=wrap;connectable=0;overflow=hidden;fillColor=none;top=0;left=0;bottom=0;right=0;fontColor=#000000;" parent="164" vertex="1">
+                <mxCell id="165" value="shipping_charge_id" style="shape=partialRectangle;html=1;whiteSpace=wrap;connectable=0;overflow=hidden;fillColor=none;top=0;left=0;bottom=0;right=0;fontColor=#000000;" parent="164" vertex="1">
                     <mxGeometry width="120" height="43" as="geometry"/>
                 </mxCell>
                 <mxCell id="166" value="integer" style="shape=partialRectangle;html=1;whiteSpace=wrap;connectable=0;overflow=hidden;fillColor=none;top=0;left=0;bottom=0;right=0;fontColor=#000000;" parent="164" vertex="1">


### PR DESCRIPTION
出品者が登録した商品データ(画像/商品名/価格/配送料の負担)を、トップページに一覧表示する
[変更箇所]
itemsテーブルのカラム名を一部変更
shipping_charges_id　→　shipping_charge_id
※Activehashを使う場合、テーブル名(単数系)_idが基本。
  モデルのファイル名・クラス名も単数系に統一するため。

[挙動]
https://gyazo.com/a0b9a87f0496e2749cd273e35d7c08ae